### PR TITLE
Event creation outside EventDispatcher

### DIFF
--- a/src/eventSystem/Event.hpp
+++ b/src/eventSystem/Event.hpp
@@ -4,10 +4,12 @@
 #include <cstdint>
 
 // Base Event Class with Type ID Support
-class Event {
-public:
+struct Event {
+    std::int32_t id;
+
+    Event(std::int32_t id) : id(id) {}
+
     virtual ~Event() = default;
-    virtual std::int32_t getID() const = 0;
 
     //gives a unique ID to every subclass of Event
     template <typename T> static std::int32_t getEventID() {
@@ -20,24 +22,24 @@ private:
 };
 
 
-class EventA : public Event {
+struct EventA : public Event {
 public:
     std::int32_t data;
-    EventA(std::int32_t data) : data(data) {}
 
-    // Return the unique type ID for EventA
-    std::int32_t getID() const override {
-        return getEventID<EventA>();
-    }
+    EventA(std::int32_t data) :Event(getEventID<EventA>()), data(data) {}
+
+
 };
 
-class EventB : public Event {
+struct EventB : public Event {
 public:
     std::string message;
-    EventB(const std::string& message) : message(message) {}
+    EventB(const std::string& message) :Event(getEventID<EventB>()), message(message) {}
+};
 
-        // Return the unique type ID for EventA
-    std::int32_t getID() const override {
-        return getEventID<EventB>();
-    }
+struct EventResize : public Event{
+public:
+    std::int32_t newWidth = 0;
+    std::int32_t newHeight = 0;
+    EventResize() :Event(getEventID<EventResize>()){}
 };

--- a/src/eventSystem/EventDispatcher.hpp
+++ b/src/eventSystem/EventDispatcher.hpp
@@ -23,7 +23,7 @@ class EventDispatcher {
     using Callback = void(*)(Event*);
 
     std::map<std::int32_t, std::vector<Callback>> subscribers;
-    std::queue<std::unique_ptr<Event>> eventQueue;
+    std::queue<Event*> eventQueue;
 
 public:
     // Subscribe to a specific event type
@@ -33,24 +33,23 @@ public:
     }
 
     // Enqueue an event by constructing it in place
-    template <typename EventType, typename... Args>
-    void enqueue(Args&&... args) {
-        eventQueue.push(std::make_unique<EventType>(std::forward<Args>(args)...));
+    void enqueue(Event* event) {
+        eventQueue.push(event);
     }
 
     // Process all events in the queue
     void process() {
         while (!eventQueue.empty()) {
-            std::unique_ptr<Event> event = std::move(eventQueue.front());
+            Event* event = eventQueue.front();
             eventQueue.pop();
-            dispatch(event.get());
+            dispatch(event);
         }
     }
 
 private:
     // Dispatch an event to all relevant callbacks
     void dispatch(Event* event) {
-        auto it = subscribers.find(event->getID());
+        auto it = subscribers.find(event->id);
         if (it != subscribers.end()) {
             for (Callback callback : it->second) {
                 callback(event);


### PR DESCRIPTION
Changed the creation of events to be handled seperatly from the dispatcher. Also needed to change unique pointers into raw pointers since I'll be sending the EventDispatcher as a reference (dependancy injection). A queue of unique pointers can't handle this.