### PR TITLE
Reimplemented windowSystem

### DIFF
--- a/src/core/Types.hpp
+++ b/src/core/Types.hpp
@@ -11,3 +11,10 @@ using uint8 = std::uint8_t;
 using uint16 = std::uint16_t;
 using uint32 = std::uint32_t;
 using uint64 = std::uint64_t;
+
+#if defined(_WIN32)
+    #include "../windowSystem/Win32Window.hpp"
+    typedef Win32Window WindowManager;
+#else
+    #error "Unsupported platform"
+#endif

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,11 +1,31 @@
-#include <vk_mem_alloc.h>
-#include <glm/vec3.hpp>
-#include <stb_image.h>
-#include <tiny_obj_loader.h>
+#include "core/Types.hpp"
+#include "eventSystem/EventDispatcher.hpp"
+#include "windowSystem/Win32Window.hpp"
 
-#include <iostream>
+#include <iostream> //removable later
+
+
+
+
+void onResize(Event* e) {
+    EventResize* eventResize = static_cast<EventResize*>(e);
+    std::cout << "new width: " << eventResize->newWidth << std::endl;
+    std::cout << "new height: " << eventResize->newHeight << std::endl;
+}
+
 int main(int argc, char const *argv[])
 {
+    EventDispatcher eventDis;
+
+    eventDis.subscribe<EventResize>(onResize);
+
+
     std::cout << "Hello ExhibitEngine!" << std::endl;
+
+    WindowManager window(eventDis, 800, 500);
+
+    while(window.handleEvents()){
+        eventDis.process();
+    }
     return 0;
 }

--- a/src/windowSystem/Win32Window.hpp
+++ b/src/windowSystem/Win32Window.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "WindowInterface.hpp"
+#include <windows.h>
+
+class Win32Window : public WindowInterface {
+public:
+    Win32Window(EventDispatcher& eventDispatcher, int width, int height):WindowInterface(eventDispatcher, width, height){
+        createWindow();
+    }
+    void createWindow() override {
+        WNDCLASS wc = {};
+        wc.lpfnWndProc = WindowProc;
+        wc.hInstance = GetModuleHandle(NULL);
+        wc.lpszClassName = "Win32WindowClass";
+        wc.hCursor = LoadCursor(NULL, IDC_ARROW);  // Load a default arrow cursor
+
+        RegisterClass(&wc);
+
+        hwnd = CreateWindowEx(
+            0,                      // Optional window styles
+            "Win32WindowClass",     // Window class
+            title,                  // Window title
+            WS_OVERLAPPEDWINDOW,    // Window style
+            CW_USEDEFAULT, CW_USEDEFAULT, width, height,
+            NULL,                   // Parent window    
+            NULL,                   // Menu
+            GetModuleHandle(NULL),  // Instance handle
+            NULL                    // Additional application data
+        );
+
+        ShowWindow(hwnd, SW_SHOW);
+    }
+
+    bool handleEvents() override {
+        bool running = true;
+        MSG msg = {};
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
+            if (msg.message == WM_QUIT) {
+                running = false;
+            }
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+        //this can probably be handled better but i only want to send 1 event per game loop
+        if((eventResize.newWidth!= width) || (eventResize.newHeight!=height)){
+            width = eventResize.newWidth;
+            height = eventResize.newHeight;
+            eventDispatcher.enqueue(&eventResize);
+        }
+        return running;
+    }
+
+    void closeWindow() override {
+        DestroyWindow(hwnd);
+    }
+private:
+    HWND hwnd;
+
+    static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+        switch (uMsg) {
+        case WM_DESTROY:
+            PostQuitMessage(0);
+            break;
+        case WM_SIZE:
+            eventResize.newWidth = LOWORD(lParam);
+            eventResize.newHeight = HIWORD(lParam);
+            break;
+        default: 
+            return DefWindowProc(hwnd, uMsg, wParam, lParam);
+        }
+        return 0;
+    }
+};
+
+

--- a/src/windowSystem/WindowInterface.hpp
+++ b/src/windowSystem/WindowInterface.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "../eventSystem/EventDispatcher.hpp"
+
+class WindowInterface {
+public:
+    WindowInterface(EventDispatcher& eventDispatcher, int width, int height):
+        eventDispatcher(eventDispatcher),
+        width(width),
+        height(height){
+    }
+
+
+    virtual ~WindowInterface() = default;
+
+    virtual void createWindow() = 0;
+    virtual bool handleEvents() = 0;
+    virtual void closeWindow() = 0;
+protected:
+    int width;
+    int height;
+    const char* title = "ExhibitEngine";
+    EventDispatcher& eventDispatcher;
+    inline static EventResize eventResize;
+};


### PR DESCRIPTION
Reimplementation uses an interface to enable different platforms to be added. Sends the eventDispatcher with depencency injection, resize evnt works but could probably be handled better.