### PR TITLE
Removing pre-optimization from the event system

### DIFF
--- a/src/eventSystem/Event.hpp
+++ b/src/eventSystem/Event.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <cstdint>
 
 // Base Event Class with Type ID Support
 struct Event {
@@ -23,23 +22,20 @@ private:
 
 
 struct EventA : public Event {
-public:
+    EventA(uint32 data = 0) :Event(getEventID<EventA>()), data(data) {}
+    
     uint32 data;
-
-    EventA(uint32 data) :Event(getEventID<EventA>()), data(data) {}
-
-
 };
 
 struct EventB : public Event {
-public:
+    EventB(const std::string& message = "") :Event(getEventID<EventB>()), message(message) {}
+
     std::string message;
-    EventB(const std::string& message) :Event(getEventID<EventB>()), message(message) {}
 };
 
 struct EventResize : public Event{
-public:
-    int32 newWidth = 0;
-    int32 newHeight = 0;
-    EventResize() :Event(getEventID<EventResize>()){}
+    EventResize(int32 newWidth = 0, int32 newHeight= 0) :Event(getEventID<EventResize>()), newWidth(newWidth), newHeight(newHeight){}
+
+    int32 newWidth;
+    int32 newHeight;
 };

--- a/src/windowSystem/Win32Window.hpp
+++ b/src/windowSystem/Win32Window.hpp
@@ -46,7 +46,7 @@ public:
         if((eventResize.newWidth!= width) || (eventResize.newHeight!=height)){
             width = eventResize.newWidth;
             height = eventResize.newHeight;
-            eventDispatcher.enqueue(&eventResize);
+            eventDispatcher.enqueue(EventResize(width,height));
         }
         return running;
     }


### PR DESCRIPTION
It's good to think about how I should design an event system, especially when efficiency is important in the main loop. However, I think optimization that doesn't change the underlying structure of my solution should be deferred.